### PR TITLE
feat: confirm for fetch_shipping_rates

### DIFF
--- a/erpnext_shipping/public/js/shipment.js
+++ b/erpnext_shipping/public/js/shipment.js
@@ -5,7 +5,19 @@ frappe.ui.form.on("Shipment", {
 	refresh: function (frm) {
 		if (frm.doc.docstatus === 1 && !frm.doc.shipment_id) {
 			frm.add_custom_button(__("Fetch Shipping Rates"), function () {
-				return frm.events.fetch_shipping_rates(frm);
+				if (frm.doc.shipment_parcel.length > 1) {
+					frappe.confirm(
+						__(
+							"If your shipment contains packages with varying weights, the estimated shipping rates may differ from the final price charged by your carrier. Do you wish to proceed?"
+						),
+						function () {
+							frm.events.fetch_shipping_rates(frm);
+						},
+						function () {}
+					);
+				} else {
+					frm.events.fetch_shipping_rates(frm);
+				}
 			});
 		}
 		if (frm.doc.shipment_id) {

--- a/erpnext_shipping/public/js/shipment.js
+++ b/erpnext_shipping/public/js/shipment.js
@@ -12,8 +12,7 @@ frappe.ui.form.on("Shipment", {
 						),
 						function () {
 							frm.events.fetch_shipping_rates(frm);
-						},
-						function () {}
+						}
 					);
 				} else {
 					frm.events.fetch_shipping_rates(frm);


### PR DESCRIPTION
- displays a confirmation dialog warning the user that fetching shipping options for multiple parcels may result in a final price that differs from the initial estimate