### PR TITLE
fix: parse JSON first

### DIFF
--- a/erpnext_shipping/erpnext_shipping/shipping.py
+++ b/erpnext_shipping/erpnext_shipping/shipping.py
@@ -102,7 +102,9 @@ def create_shipment(
 	delivery_contact_name=None,
 	delivery_notes=None,
 ):
-	# Create Shipment for the selected provider
+	if isinstance(delivery_notes, str):
+		delivery_notes = json.loads(delivery_notes)
+
 	if delivery_notes is None:
 		delivery_notes = []
 
@@ -219,6 +221,9 @@ def save_label_as_attachment(shipment: str, content: bytes, index: int = None) -
 
 @frappe.whitelist()
 def update_tracking(shipment, service_provider, shipment_id, delivery_notes=None):
+	if isinstance(delivery_notes, str):
+		delivery_notes = json.loads(delivery_notes)
+
 	if delivery_notes is None:
 		delivery_notes = []
 
@@ -251,9 +256,6 @@ def update_tracking(shipment, service_provider, shipment_id, delivery_notes=None
 def update_delivery_note(delivery_notes, shipment_info=None, tracking_info=None):
 	# Update Shipment Info in Delivery Note
 	# Using db_set since some services might not exist
-	if isinstance(delivery_notes, str):
-		delivery_notes = json.loads(delivery_notes)
-
 	delivery_notes = list(set(delivery_notes))
 
 	for delivery_note in delivery_notes:

--- a/erpnext_shipping/public/js/shipment.js
+++ b/erpnext_shipping/public/js/shipment.js
@@ -127,10 +127,8 @@ frappe.ui.form.on("Shipment", {
 	},
 
 	update_tracking: function (frm, service_provider, shipment_id) {
-		let delivery_notes = [];
-		(frm.doc.shipment_delivery_note || []).forEach((d) => {
-			delivery_notes.push(d.delivery_note);
-		});
+		const delivery_notes = frm.doc.shipment_delivery_note.map((d) => d.delivery_note);
+
 		frappe.call({
 			method: "erpnext_shipping.erpnext_shipping.shipping.update_tracking",
 			freeze: true,
@@ -175,10 +173,7 @@ function select_from_available_services(frm, available_services) {
 		],
 	});
 
-	let delivery_notes = [];
-	(frm.doc.shipment_delivery_note || []).forEach((d) => {
-		delivery_notes.push(d.delivery_note);
-	});
+	const delivery_notes = frm.doc.shipment_delivery_note.map((d) => d.delivery_note);
 
 	dialog.fields_dict.available_services.$wrapper.html(
 		frappe.render_template("shipment_service_selector", {


### PR DESCRIPTION
- When we check for `if delivery_notes`, the value needs to be parsed already. Otherwise, `'[]'` always evaluates to `True`.
- On the JS side, we can construct the array of delivery notes a bit more elegantly, using `Array.map()`.