### PR TITLE
refactor: currency handling for LetMeShip and SendCloud

### DIFF
--- a/erpnext_shipping/erpnext_shipping/doctype/letmeship/letmeship.py
+++ b/erpnext_shipping/erpnext_shipping/doctype/letmeship/letmeship.py
@@ -282,6 +282,7 @@ class LetMeShipUtils:
 		available_service.real_weight = price_info["realWeight"]
 		available_service.total_price = price_info["netPrice"]
 		available_service.price_info = price_info
+		available_service.currency = "USD"
 		return available_service
 
 	def set_letmeship_specific_fields(self, pickup_contact, delivery_contact):

--- a/erpnext_shipping/erpnext_shipping/doctype/letmeship/letmeship.py
+++ b/erpnext_shipping/erpnext_shipping/doctype/letmeship/letmeship.py
@@ -282,7 +282,7 @@ class LetMeShipUtils:
 		available_service.real_weight = price_info["realWeight"]
 		available_service.total_price = price_info["netPrice"]
 		available_service.price_info = price_info
-		available_service.currency = "USD"
+		available_service.currency = "EUR"
 		return available_service
 
 	def set_letmeship_specific_fields(self, pickup_contact, delivery_contact):

--- a/erpnext_shipping/erpnext_shipping/doctype/letmeship/letmeship.py
+++ b/erpnext_shipping/erpnext_shipping/doctype/letmeship/letmeship.py
@@ -282,6 +282,8 @@ class LetMeShipUtils:
 		available_service.real_weight = price_info["realWeight"]
 		available_service.total_price = price_info["netPrice"]
 		available_service.price_info = price_info
+		available_service.currency = "EUR"
+
 		return available_service
 
 	def set_letmeship_specific_fields(self, pickup_contact, delivery_contact):

--- a/erpnext_shipping/erpnext_shipping/doctype/letmeship/letmeship.py
+++ b/erpnext_shipping/erpnext_shipping/doctype/letmeship/letmeship.py
@@ -282,8 +282,6 @@ class LetMeShipUtils:
 		available_service.real_weight = price_info["realWeight"]
 		available_service.total_price = price_info["netPrice"]
 		available_service.price_info = price_info
-		available_service.currency = "EUR"
-
 		return available_service
 
 	def set_letmeship_specific_fields(self, pickup_contact, delivery_contact):

--- a/erpnext_shipping/erpnext_shipping/doctype/sendcloud/sendcloud.py
+++ b/erpnext_shipping/erpnext_shipping/doctype/sendcloud/sendcloud.py
@@ -323,11 +323,13 @@ class SendCloudUtils:
 		available_service.service_id = service["code"]
 		available_service.multicollo = service["functionalities"].get("multicollo", False)
 
-		price = 0
-		if "quotes" in service and service["quotes"]:
-			price = float(service["quotes"][0]["price"]["total"]["value"])
-			available_service.total_price = self.total_parcel_price(price, parcels)
-			available_service.currency = service["quotes"][0]["price"]["total"]["currency"]
+		quotes = service.get("quotes", [])
+		if quotes:
+			price_data = quotes[0].get("price", {}).get("total", {})
+			available_service.total_price = self.total_parcel_price(
+				float(price_data.get("value", 0)), parcels
+			)
+			available_service.currency = price_data.get("currency")
 
 		return available_service
 

--- a/erpnext_shipping/erpnext_shipping/doctype/sendcloud/sendcloud.py
+++ b/erpnext_shipping/erpnext_shipping/doctype/sendcloud/sendcloud.py
@@ -327,7 +327,6 @@ class SendCloudUtils:
 		if "quotes" in service and service["quotes"]:
 			price = float(service["quotes"][0]["price"]["total"]["value"])
 			available_service.total_price = self.total_parcel_price(price, parcels)
-			available_service.currency = service["quotes"][0]["price"]["total"]["currency"]
 
 		return available_service
 

--- a/erpnext_shipping/erpnext_shipping/doctype/sendcloud/sendcloud.py
+++ b/erpnext_shipping/erpnext_shipping/doctype/sendcloud/sendcloud.py
@@ -327,6 +327,7 @@ class SendCloudUtils:
 		if "quotes" in service and service["quotes"]:
 			price = float(service["quotes"][0]["price"]["total"]["value"])
 			available_service.total_price = self.total_parcel_price(price, parcels)
+			available_service.currency = service["quotes"][0]["price"]["total"]["currency"]
 
 		return available_service
 

--- a/erpnext_shipping/public/js/shipment_service_selector.html
+++ b/erpnext_shipping/public/js/shipment_service_selector.html
@@ -16,7 +16,7 @@
 							<td class="service-info" style="width:20%;">{{ data.preferred_services[i].service_provider }}</td>
 							<td class="service-info" style="width:20%;">{{ data.preferred_services[i].carrier }}</td>
 							<td class="service-info" style="width:40%;">{{ data.preferred_services[i].service_name }}</td>
-							<td class="service-info" style="width:20%;">{{ format_currency(data.preferred_services[i].total_price, "EUR", 2) }}</td>
+							<td class="service-info" style="width:20%;">{{ format_currency(data.preferred_services[i].total_price, data.preferred_services[i].currency, 2) }}</td>
 							<td style="width:10%;vertical-align: middle;">
 								<button
 									data-type="preferred_services"
@@ -51,7 +51,7 @@
 							<td class="service-info" style="width:20%;">{{ data.other_services[i].service_provider }}</td>
 							<td class="service-info" style="width:20%;">{{ data.other_services[i].carrier }}</td>
 							<td class="service-info" style="width:40%;">{{ data.other_services[i].service_name }}</td>
-							<td class="service-info" style="width:20%;">{{ format_currency(data.other_services[i].total_price, "EUR", 2) }}</td>
+							<td class="service-info" style="width:20%;">{{ format_currency(data.other_services[i].total_price, data.other_services[i].currency, 2) }}</td>
 							<td style="width:10%;vertical-align: middle;">
 								<button
 									data-type="other_services"

--- a/erpnext_shipping/public/js/shipment_service_selector.html
+++ b/erpnext_shipping/public/js/shipment_service_selector.html
@@ -1,96 +1,114 @@
 {% if (data.preferred_services.length || data.other_services.length) { %}
-	<div style="overflow-x:scroll;">
-		<h5>{{ __("Preferred Services") }}</h5>
-		{% if (data.preferred_services.length) { %}
-			<table class="table table-bordered table-hover">
-				<thead class="grid-heading-row">
-					<tr>
-						{% for (var i = 0; i < header_columns.length; i++) { %}
-							<th style="padding-left: 12px;">{{ header_columns[i] }}</th>
-						{% } %}
-					</tr>
-				</thead>
-				<tbody>
-					{% for (var i = 0; i < data.preferred_services.length; i++) { %}
-						<tr id="data-preferred-{{i}}">
-							<td class="service-info" style="width:20%;">{{ data.preferred_services[i].service_provider }}</td>
-							<td class="service-info" style="width:20%;">{{ data.preferred_services[i].carrier }}</td>
-							<td class="service-info" style="width:40%;">{{ data.preferred_services[i].service_name }}</td>
-							<td class="service-info" style="width:20%;">{{ format_currency(data.preferred_services[i].total_price, "EUR", 2) }}</td>
-							<td style="width:10%;vertical-align: middle;">
-								<button
-									data-type="preferred_services"
-									id="data-preferred-{{i}}" type="button" class="btn">
-									{{ __("Select") }}
-								</button>
-							</td>
-						</tr>
-					{% } %}
-				</tbody>
-			</table>
-		{% } else { %}
-			<div style="text-align: center; padding: 10px;">
-				<span class="text-muted">
-					{{ __("No Preferred Services Available") }}
-				</span>
-			</div>
-		{% } %}
-		<h5>{{ __("Other Services") }}</h5>
-		{% if (data.other_services.length) { %}
-			<table class="table table-bordered table-hover">
-				<thead class="grid-heading-row">
-					<tr>
-						{% for (var i = 0; i < header_columns.length; i++) { %}
-							<th style="padding-left: 12px;" >{{ header_columns[i] }}</th>
-						{% } %}
-					</tr>
-				</thead>
-				<tbody>
-					{% for (var i = 0; i < data.other_services.length; i++) { %}
-						<tr id="data-other-{{i}}">
-							<td class="service-info" style="width:20%;">{{ data.other_services[i].service_provider }}</td>
-							<td class="service-info" style="width:20%;">{{ data.other_services[i].carrier }}</td>
-							<td class="service-info" style="width:40%;">{{ data.other_services[i].service_name }}</td>
-							<td class="service-info" style="width:20%;">{{ format_currency(data.other_services[i].total_price, "EUR", 2) }}</td>
-							<td style="width:10%;vertical-align: middle;">
-								<button
-									data-type="other_services"
-									id="data-other-{{i}}" type="button" class="btn">
-									{{ __("Select") }}
-								</button>
-							</td>
-						</tr>
-					{% } %}
-				</tbody>
-			</table>
-		{% } else { %}
-		<div style="text-align: center; padding: 10px;">
-			<span class="text-muted">
-				{{ __("No Services Available") }}
-			</span>
-		</div>
-		{% } %}
+<div style="overflow-x: scroll">
+	<h5>{{ __("Preferred Services") }}</h5>
+	{% if (data.preferred_services.length) { %}
+	<table class="table table-bordered table-hover">
+		<thead class="grid-heading-row">
+			<tr>
+				{% for (var i = 0; i < header_columns.length; i++) { %}
+				<th style="padding-left: 12px">{{ header_columns[i] }}</th>
+				{% } %}
+			</tr>
+		</thead>
+		<tbody>
+			{% for (var i = 0; i < data.preferred_services.length; i++) { %}
+			<tr id="data-preferred-{{i}}">
+				<td class="service-info" style="width: 20%">
+					{{ data.preferred_services[i].service_provider }}
+				</td>
+				<td class="service-info" style="width: 20%">
+					{{ data.preferred_services[i].carrier }}
+				</td>
+				<td class="service-info" style="width: 40%">
+					{{ data.preferred_services[i].service_name }}
+				</td>
+				<td class="service-info" style="width: 20%">
+					{{ format_currency(data.preferred_services[i].total_price,
+					data.preferred_services[i].currency, 2) }}
+				</td>
+				<td style="width: 10%; vertical-align: middle">
+					<button
+						data-type="preferred_services"
+						id="data-preferred-{{i}}"
+						type="button"
+						class="btn"
+					>
+						{{ __("Select") }}
+					</button>
+				</td>
+			</tr>
+			{% } %}
+		</tbody>
+	</table>
+	{% } else { %}
+	<div style="text-align: center; padding: 10px">
+		<span class="text-muted"> {{ __("No Preferred Services Available") }} </span>
 	</div>
+	{% } %}
+	<h5>{{ __("Other Services") }}</h5>
+	{% if (data.other_services.length) { %}
+	<table class="table table-bordered table-hover">
+		<thead class="grid-heading-row">
+			<tr>
+				{% for (var i = 0; i < header_columns.length; i++) { %}
+				<th style="padding-left: 12px">{{ header_columns[i] }}</th>
+				{% } %}
+			</tr>
+		</thead>
+		<tbody>
+			{% for (var i = 0; i < data.other_services.length; i++) { %}
+			<tr id="data-other-{{i}}">
+				<td class="service-info" style="width: 20%">
+					{{ data.other_services[i].service_provider }}
+				</td>
+				<td class="service-info" style="width: 20%">
+					{{ data.other_services[i].carrier }}
+				</td>
+				<td class="service-info" style="width: 40%">
+					{{ data.other_services[i].service_name }}
+				</td>
+				<td class="service-info" style="width: 20%">
+					{{ format_currency(data.other_services[i].total_price,
+					data.other_services[i].currency, 2) }}
+				</td>
+				<td style="width: 10%; vertical-align: middle">
+					<button
+						data-type="other_services"
+						id="data-other-{{i}}"
+						type="button"
+						class="btn"
+					>
+						{{ __("Select") }}
+					</button>
+				</td>
+			</tr>
+			{% } %}
+		</tbody>
+	</table>
+	{% } else { %}
+	<div style="text-align: center; padding: 10px">
+		<span class="text-muted"> {{ __("No Services Available") }} </span>
+	</div>
+	{% } %}
+</div>
 {% } else { %}
-	<div style="text-align: center; padding: 10px;">
-		<span class="text-muted">
-			{{ __("No Services Available") }}
-		</span>
-	</div>
+<div style="text-align: center; padding: 10px">
+	<span class="text-muted"> {{ __("No Services Available") }} </span>
+</div>
 {% } %}
 
 <style type="text/css" media="screen">
-.modal-dialog {
-	width: 750px;
-}
-.service-info {
-	vertical-align: middle !important;
-	padding-left: 12px !important;
-}
-.btn:hover {
-	background-color: #dedede;
-}
-.ship {
-	font-size: 16px;
-}
+	.modal-dialog {
+		width: 750px;
+	}
+	.service-info {
+		vertical-align: middle !important;
+		padding-left: 12px !important;
+	}
+	.btn:hover {
+		background-color: #dedede;
+	}
+	.ship {
+		font-size: 16px;
+	}
 </style>

--- a/erpnext_shipping/public/js/shipment_service_selector.html
+++ b/erpnext_shipping/public/js/shipment_service_selector.html
@@ -1,114 +1,96 @@
 {% if (data.preferred_services.length || data.other_services.length) { %}
-<div style="overflow-x: scroll">
-	<h5>{{ __("Preferred Services") }}</h5>
-	{% if (data.preferred_services.length) { %}
-	<table class="table table-bordered table-hover">
-		<thead class="grid-heading-row">
-			<tr>
-				{% for (var i = 0; i < header_columns.length; i++) { %}
-				<th style="padding-left: 12px">{{ header_columns[i] }}</th>
-				{% } %}
-			</tr>
-		</thead>
-		<tbody>
-			{% for (var i = 0; i < data.preferred_services.length; i++) { %}
-			<tr id="data-preferred-{{i}}">
-				<td class="service-info" style="width: 20%">
-					{{ data.preferred_services[i].service_provider }}
-				</td>
-				<td class="service-info" style="width: 20%">
-					{{ data.preferred_services[i].carrier }}
-				</td>
-				<td class="service-info" style="width: 40%">
-					{{ data.preferred_services[i].service_name }}
-				</td>
-				<td class="service-info" style="width: 20%">
-					{{ format_currency(data.preferred_services[i].total_price,
-					data.preferred_services[i].currency, 2) }}
-				</td>
-				<td style="width: 10%; vertical-align: middle">
-					<button
-						data-type="preferred_services"
-						id="data-preferred-{{i}}"
-						type="button"
-						class="btn"
-					>
-						{{ __("Select") }}
-					</button>
-				</td>
-			</tr>
-			{% } %}
-		</tbody>
-	</table>
-	{% } else { %}
-	<div style="text-align: center; padding: 10px">
-		<span class="text-muted"> {{ __("No Preferred Services Available") }} </span>
+	<div style="overflow-x:scroll;">
+		<h5>{{ __("Preferred Services") }}</h5>
+		{% if (data.preferred_services.length) { %}
+			<table class="table table-bordered table-hover">
+				<thead class="grid-heading-row">
+					<tr>
+						{% for (var i = 0; i < header_columns.length; i++) { %}
+							<th style="padding-left: 12px;">{{ header_columns[i] }}</th>
+						{% } %}
+					</tr>
+				</thead>
+				<tbody>
+					{% for (var i = 0; i < data.preferred_services.length; i++) { %}
+						<tr id="data-preferred-{{i}}">
+							<td class="service-info" style="width:20%;">{{ data.preferred_services[i].service_provider }}</td>
+							<td class="service-info" style="width:20%;">{{ data.preferred_services[i].carrier }}</td>
+							<td class="service-info" style="width:40%;">{{ data.preferred_services[i].service_name }}</td>
+							<td class="service-info" style="width:20%;">{{ format_currency(data.preferred_services[i].total_price, "EUR", 2) }}</td>
+							<td style="width:10%;vertical-align: middle;">
+								<button
+									data-type="preferred_services"
+									id="data-preferred-{{i}}" type="button" class="btn">
+									{{ __("Select") }}
+								</button>
+							</td>
+						</tr>
+					{% } %}
+				</tbody>
+			</table>
+		{% } else { %}
+			<div style="text-align: center; padding: 10px;">
+				<span class="text-muted">
+					{{ __("No Preferred Services Available") }}
+				</span>
+			</div>
+		{% } %}
+		<h5>{{ __("Other Services") }}</h5>
+		{% if (data.other_services.length) { %}
+			<table class="table table-bordered table-hover">
+				<thead class="grid-heading-row">
+					<tr>
+						{% for (var i = 0; i < header_columns.length; i++) { %}
+							<th style="padding-left: 12px;" >{{ header_columns[i] }}</th>
+						{% } %}
+					</tr>
+				</thead>
+				<tbody>
+					{% for (var i = 0; i < data.other_services.length; i++) { %}
+						<tr id="data-other-{{i}}">
+							<td class="service-info" style="width:20%;">{{ data.other_services[i].service_provider }}</td>
+							<td class="service-info" style="width:20%;">{{ data.other_services[i].carrier }}</td>
+							<td class="service-info" style="width:40%;">{{ data.other_services[i].service_name }}</td>
+							<td class="service-info" style="width:20%;">{{ format_currency(data.other_services[i].total_price, "EUR", 2) }}</td>
+							<td style="width:10%;vertical-align: middle;">
+								<button
+									data-type="other_services"
+									id="data-other-{{i}}" type="button" class="btn">
+									{{ __("Select") }}
+								</button>
+							</td>
+						</tr>
+					{% } %}
+				</tbody>
+			</table>
+		{% } else { %}
+		<div style="text-align: center; padding: 10px;">
+			<span class="text-muted">
+				{{ __("No Services Available") }}
+			</span>
+		</div>
+		{% } %}
 	</div>
-	{% } %}
-	<h5>{{ __("Other Services") }}</h5>
-	{% if (data.other_services.length) { %}
-	<table class="table table-bordered table-hover">
-		<thead class="grid-heading-row">
-			<tr>
-				{% for (var i = 0; i < header_columns.length; i++) { %}
-				<th style="padding-left: 12px">{{ header_columns[i] }}</th>
-				{% } %}
-			</tr>
-		</thead>
-		<tbody>
-			{% for (var i = 0; i < data.other_services.length; i++) { %}
-			<tr id="data-other-{{i}}">
-				<td class="service-info" style="width: 20%">
-					{{ data.other_services[i].service_provider }}
-				</td>
-				<td class="service-info" style="width: 20%">
-					{{ data.other_services[i].carrier }}
-				</td>
-				<td class="service-info" style="width: 40%">
-					{{ data.other_services[i].service_name }}
-				</td>
-				<td class="service-info" style="width: 20%">
-					{{ format_currency(data.other_services[i].total_price,
-					data.other_services[i].currency, 2) }}
-				</td>
-				<td style="width: 10%; vertical-align: middle">
-					<button
-						data-type="other_services"
-						id="data-other-{{i}}"
-						type="button"
-						class="btn"
-					>
-						{{ __("Select") }}
-					</button>
-				</td>
-			</tr>
-			{% } %}
-		</tbody>
-	</table>
-	{% } else { %}
-	<div style="text-align: center; padding: 10px">
-		<span class="text-muted"> {{ __("No Services Available") }} </span>
-	</div>
-	{% } %}
-</div>
 {% } else { %}
-<div style="text-align: center; padding: 10px">
-	<span class="text-muted"> {{ __("No Services Available") }} </span>
-</div>
+	<div style="text-align: center; padding: 10px;">
+		<span class="text-muted">
+			{{ __("No Services Available") }}
+		</span>
+	</div>
 {% } %}
 
 <style type="text/css" media="screen">
-	.modal-dialog {
-		width: 750px;
-	}
-	.service-info {
-		vertical-align: middle !important;
-		padding-left: 12px !important;
-	}
-	.btn:hover {
-		background-color: #dedede;
-	}
-	.ship {
-		font-size: 16px;
-	}
+.modal-dialog {
+	width: 750px;
+}
+.service-info {
+	vertical-align: middle !important;
+	padding-left: 12px !important;
+}
+.btn:hover {
+	background-color: #dedede;
+}
+.ship {
+	font-size: 16px;
+}
 </style>


### PR DESCRIPTION
This PR refactors the shipping service currency handling to remove hardcoded currency from the frontend. 

**SendCloud:**
The currency value is now retrieved directly from the API response.

**LetMeShip:**
Since LetMeShip only supports EUR, its currency remains hardcoded in the backend.

Resolves #33 