### PR TITLE
refactor: delete validate_phone

### DIFF
--- a/erpnext_shipping/erpnext_shipping/shipping.py
+++ b/erpnext_shipping/erpnext_shipping/shipping.py
@@ -14,8 +14,6 @@ from erpnext_shipping.erpnext_shipping.utils import (
 	get_address,
 	get_contact,
 	match_parcel_service_type_carrier,
-	validate_parcels,
-	validate_phone,
 )
 
 

--- a/erpnext_shipping/erpnext_shipping/utils.py
+++ b/erpnext_shipping/erpnext_shipping/utils.py
@@ -62,19 +62,6 @@ def validate_parcels(doc, method=None):
 				)
 
 
-def validate_phone(doc, method=None):
-	if doc.pickup_from_type == "Company":
-		phone_number = frappe.db.get_value("User", doc.pickup_contact_person, "phone")
-	else:
-		phone_number = frappe.db.get_value("Contact", doc.pickup_contact_name, "phone")
-
-	if not phone_number:
-		frappe.throw(_("Pickup contact phone is required."))
-
-	if not re.match(r"^\+(?!0)\d+$", phone_number):
-		frappe.throw(_("Pickup contact phone must consist of a '+' followed by one or more digits."))
-
-
 def get_country_code(country_name):
 	country_code = frappe.db.get_value("Country", country_name, "code")
 	if not country_code:

--- a/erpnext_shipping/hooks.py
+++ b/erpnext_shipping/hooks.py
@@ -200,9 +200,6 @@ shipping_custom_fields = {
 
 doc_events = {
 	"Shipment": {
-		"validate": [
-			"erpnext_shipping.erpnext_shipping.utils.validate_parcels",
-			"erpnext_shipping.erpnext_shipping.utils.validate_phone",
-		]
+		"validate": "erpnext_shipping.erpnext_shipping.utils.validate_parcels",
 	},
 }


### PR DESCRIPTION
SendCloud no longer requires a phone number at all, nor does it require a specific format. So validate_phone has been removed.