### PR TITLE
fix: phone number validation

### DIFF
--- a/erpnext_shipping/erpnext_shipping/shipping.py
+++ b/erpnext_shipping/erpnext_shipping/shipping.py
@@ -14,8 +14,6 @@ from erpnext_shipping.erpnext_shipping.utils import (
 	get_address,
 	get_contact,
 	match_parcel_service_type_carrier,
-	validate_parcels,
-	validate_phone,
 )
 
 

--- a/erpnext_shipping/erpnext_shipping/utils.py
+++ b/erpnext_shipping/erpnext_shipping/utils.py
@@ -71,7 +71,7 @@ def validate_phone(doc, method=None):
 	if not phone_number:
 		frappe.throw(_("Pickup contact phone is required."))
 
-	if not re.match(r"^\+(?!\s*0)[\d\s]+$", phone_number):
+	if not re.match(r"^\+(?![\s0])[\d\s]+\d$", phone_number):
 		frappe.throw(_("Pickup contact phone must consist of a '+' followed by one or more digits."))
 
 

--- a/erpnext_shipping/erpnext_shipping/utils.py
+++ b/erpnext_shipping/erpnext_shipping/utils.py
@@ -71,7 +71,7 @@ def validate_phone(doc, method=None):
 	if not phone_number:
 		frappe.throw(_("Pickup contact phone is required."))
 
-	if not re.match(r"^\+(?!0)\d+$", phone_number):
+	if not re.match(r"^\+(?!\s*0)[\d\s]+$", phone_number):
 		frappe.throw(_("Pickup contact phone must consist of a '+' followed by one or more digits."))
 
 


### PR DESCRIPTION
LetMeShip requires a correctly formatted `phoneNumberPrefix`. We currently extract the first 3 characters from the phone number, but LetMeShip expects it to begin with a “+”.

This PR updates the regex to also allow whitespaces. 

The regex now checks that:
- the number starts with a “+”
- no zero immediately follows (to avoid formats like +0049)
- the rest of the string contains only digits and whitespace