### PR TITLE
fix(SendCloud)!: update deprecated endpoint and parcel validations

### DIFF
--- a/erpnext_shipping/erpnext_shipping/doctype/letmeship/letmeship.py
+++ b/erpnext_shipping/erpnext_shipping/doctype/letmeship/letmeship.py
@@ -88,6 +88,9 @@ class LetMeShipUtils:
 		pickup_contact=None,
 		delivery_contact=None,
 	):
+		if not self.validate_parcels(parcels):
+			return []
+
 		self.set_letmeship_specific_fields(pickup_contact, delivery_contact)
 		pickup_address.address_title = self.first_30_chars(pickup_address.address_title)
 		delivery_address.address_title = self.first_30_chars(delivery_address.address_title)
@@ -350,6 +353,18 @@ class LetMeShipUtils:
 			"phone": {"phoneNumber": contact.phone, "phoneNumberPrefix": contact.phone_prefix},
 			"email": contact.email_id,
 		}
+
+	def validate_parcels(self, parcels):
+		for parcel in parcels:
+			for field in ("length", "width", "height"):
+				if (parcel.get(field) or 0) < 1:
+					frappe.msgprint(
+						_("LetMeShip rates need parcel dimensions (length, width, height)."),
+						indicator="orange",
+						alert=True,
+					)
+					return False
+		return True
 
 
 def get_letmeship_utils() -> "LetMeShipUtils":

--- a/erpnext_shipping/erpnext_shipping/doctype/letmeship/letmeship.py
+++ b/erpnext_shipping/erpnext_shipping/doctype/letmeship/letmeship.py
@@ -89,6 +89,11 @@ class LetMeShipUtils:
 		delivery_contact=None,
 	):
 		if not self.validate_parcels(parcels):
+			frappe.msgprint(
+				_("LetMeShip rates need parcel dimensions (length, width, height)."),
+				indicator="orange",
+				alert=True,
+			)
 			return []
 
 		self.set_letmeship_specific_fields(pickup_contact, delivery_contact)
@@ -135,7 +140,7 @@ class LetMeShipUtils:
 	):
 		parcels = json.loads(shipment_parcel)
 		if not self.validate_parcels(parcels):
-			return None
+			frappe.throw(_("LetMeShip booking needs parcel dimensions (length, width, height)."))
 
 		self.set_letmeship_specific_fields(pickup_contact, delivery_contact)
 		pickup_address.address_title = self.first_30_chars(pickup_address.address_title)
@@ -362,11 +367,6 @@ class LetMeShipUtils:
 		for parcel in parcels:
 			for field in ("length", "width", "height"):
 				if (parcel.get(field) or 0) < 1:
-					frappe.msgprint(
-						_("LetMeShip rates need parcel dimensions (length, width, height)."),
-						indicator="orange",
-						alert=True,
-					)
 					return False
 		return True
 

--- a/erpnext_shipping/erpnext_shipping/doctype/letmeship/letmeship.py
+++ b/erpnext_shipping/erpnext_shipping/doctype/letmeship/letmeship.py
@@ -133,12 +133,16 @@ class LetMeShipUtils:
 		pickup_contact=None,
 		delivery_contact=None,
 	):
+		parcels = json.loads(shipment_parcel)
+		if not self.validate_parcels(parcels):
+			return None
+
 		self.set_letmeship_specific_fields(pickup_contact, delivery_contact)
 		pickup_address.address_title = self.first_30_chars(pickup_address.address_title)
 		delivery_address.address_title = self.first_30_chars(
 			delivery_company_name or delivery_address.address_title
 		)
-		parcel_list = self.get_parcel_list(json.loads(shipment_parcel), description_of_content)
+		parcel_list = self.get_parcel_list(parcels, description_of_content)
 
 		payload = self.generate_payload(
 			pickup_address=pickup_address,

--- a/erpnext_shipping/erpnext_shipping/doctype/sendcloud/sendcloud.py
+++ b/erpnext_shipping/erpnext_shipping/doctype/sendcloud/sendcloud.py
@@ -188,8 +188,12 @@ class SendCloudUtils:
 				parcels_data = response_data.get("data", {}).get("parcels", [])
 				if parcels_data:
 					shipment_ids = [str(parcel["id"]) for parcel in parcels_data]
-					tracking_numbers = [parcel.get("tracking_number") or "" for parcel in parcels_data]
-					tracking_urls = [parcel.get("tracking_url") or "" for parcel in parcels_data]
+					tracking_numbers = [
+						parcel["tracking_number"] for parcel in parcels_data if parcel.get("tracking_number")
+					]
+					tracking_urls = [
+						parcel["tracking_url"] for parcel in parcels_data if parcel.get("tracking_url")
+					]
 					return {
 						"service_provider": "SendCloud",
 						"shipment_id": ", ".join(shipment_ids),

--- a/erpnext_shipping/erpnext_shipping/doctype/sendcloud/sendcloud.py
+++ b/erpnext_shipping/erpnext_shipping/doctype/sendcloud/sendcloud.py
@@ -51,6 +51,9 @@ class SendCloudUtils:
 		max_width = max(parcel.get("width", 0) for parcel in parcels)
 		max_height = max(parcel.get("height", 0) for parcel in parcels)
 
+		for parcel in parcels:
+			self.warn_partial_dimensions(parcel)
+
 		to_country = delivery_address.country_code.upper()
 		from_country = pickup_address.country_code.upper()
 
@@ -124,6 +127,7 @@ class SendCloudUtils:
 		parcels = []
 		index = 0
 		for parcel in json.loads(shipment_parcel):
+			self.warn_partial_dimensions(parcel)
 			for idx in range(parcel.get("count", 1)):
 				index += 1
 				parcels.append(self.get_parcel(parcel, shipment, index))
@@ -397,6 +401,17 @@ class SendCloudUtils:
 			return house_number, cleaned_address
 		else:
 			return None, None
+
+	def warn_partial_dimensions(self, parcel):
+		dimensions = [parcel.get("length", 0), parcel.get("width", 0), parcel.get("height", 0)]
+		if any(dim > 0 for dim in dimensions) and not all(dim > 0 for dim in dimensions):
+			frappe.msgprint(
+				_(
+					"SendCloud ignores incomplete parcel dimensions; provide length, width, and height or leave all empty."
+				),
+				indicator="orange",
+				alert=True,
+			)
 
 	def format_api_errors(self, errors):
 		return "\n".join(

--- a/erpnext_shipping/erpnext_shipping/doctype/sendcloud/sendcloud.py
+++ b/erpnext_shipping/erpnext_shipping/doctype/sendcloud/sendcloud.py
@@ -237,15 +237,19 @@ class SendCloudUtils:
 			cancel_failed = []
 			for result in shipments_results:
 				shipment_id = result["shipment_id"]
-				success, error = self.cancel_shipment(shipment_id)
+				success, detail = self.cancel_shipment(shipment_id)
 				if success:
-					cancelled_ids.append(shipment_id)
+					cancelled_ids.append((shipment_id, detail))
 				else:
-					cancel_failed.append((shipment_id, error))
+					cancel_failed.append((shipment_id, detail))
 
 			if cancelled_ids:
+				cancelled_msg = ", ".join(
+					f"{shipment_id} ({detail})" if detail == "queued" else shipment_id
+					for shipment_id, detail in cancelled_ids
+				)
 				frappe.msgprint(
-					_("Cancelled SendCloud shipment IDs: {0}").format(", ".join(cancelled_ids)),
+					_("Cancelled SendCloud shipment IDs: {0}").format(cancelled_msg),
 					indicator="orange",
 					alert=True,
 				)
@@ -268,12 +272,36 @@ class SendCloudUtils:
 				f"{SHIPMENTS_URL}/{shipment_id}/cancel",
 				auth=(self.api_key, self.api_secret),
 			)
-			response_data = response.json()
-			if errors := response_data.get("errors"):
-				return False, self.format_api_errors(errors)
-			return True, None
 		except Exception:
 			return False, _("Request failed")
+
+		if response.status_code not in (200, 202):
+			try:
+				response_data = response.json()
+			except ValueError:
+				response_data = None
+			if response_data and (errors := response_data.get("errors")):
+				return False, self.format_api_errors(errors)
+			body = (response.text or "")[:200]
+			return False, _("Unexpected response (HTTP {0}): {1}").format(response.status_code, body)
+
+		try:
+			response_data = response.json()
+		except ValueError:
+			body = (response.text or "")[:200]
+			return False, _("Invalid JSON response (HTTP {0}): {1}").format(response.status_code, body)
+
+		if errors := response_data.get("errors"):
+			return False, self.format_api_errors(errors)
+
+		status = response_data.get("data", {}).get("status")
+		if status == "cancelled":
+			return True, "cancelled"
+		if status == "queued":
+			return True, "queued"
+
+		body = json.dumps(response_data)[:200]
+		return False, _("Unexpected cancel response: {0}").format(body)
 
 	def get_label(self, shipment_id):
 		# Retrieve shipment label from SendCloud

--- a/erpnext_shipping/erpnext_shipping/doctype/sendcloud/sendcloud.py
+++ b/erpnext_shipping/erpnext_shipping/doctype/sendcloud/sendcloud.py
@@ -20,7 +20,8 @@ CURRENCY_DECIMALS = 2
 
 BASE_URL = "https://panel.sendcloud.sc/api"
 SHIPPING_OPTIONS_URL = f"{BASE_URL}/v3/shipping-options"
-SHIPMENTS_ANNOUNCE_URL = f"{BASE_URL}/v3/shipments/announce"
+SHIPMENTS_URL = f"{BASE_URL}/v3/shipments"
+SHIPMENTS_ANNOUNCE_URL = f"{SHIPMENTS_URL}/announce"
 LABELS_URL = f"{BASE_URL}/v2/labels"
 PARCELS_URL = f"{BASE_URL}/v2/parcels"
 
@@ -169,9 +170,12 @@ class SendCloudUtils:
 		}
 
 		shipments_results = []
+		failed_parcels = []
+
 		for parcel in parcels:
 			payload_single = payload.copy()
 			payload_single["parcels"] = [parcel]
+			order_number = parcel.get("order_number")
 			try:
 				response = requests.post(
 					SHIPMENTS_ANNOUNCE_URL,
@@ -180,32 +184,30 @@ class SendCloudUtils:
 				)
 				response_data = response.json()
 				if errors := response_data.get("errors"):
-					frappe.msgprint(
-						_("Error occurred while creating shipment for parcel {0}:").format(
-							parcel.get("order_number")
-						)
-						+ f"\n{self.format_api_errors(errors)}",
-						indicator="red",
-						alert=True,
-					)
+					failed_parcels.append((order_number, self.format_api_errors(errors)))
 					continue
 
 				parcels_data = response_data.get("data", {}).get("parcels", [])
-				if parcels_data:
-					parcel_data = parcels_data[0]
-					shipments_results.append(
-						{
-							"shipment_id": str(parcel_data["id"]),
-							"awb_number": parcel_data.get("tracking_number", ""),
-							"tracking_url": parcel_data.get("tracking_url", ""),
-							"carrier": self.get_carrier(service_info["carrier"], post_or_get="post"),
-							"carrier_service": service_info["service_name"],
-							"shipment_amount": service_info["total_price"],
-						}
-					)
+				if not parcels_data:
+					failed_parcels.append((order_number, _("No parcel data returned from SendCloud.")))
+					continue
+
+				parcel_data = parcels_data[0]
+				shipments_results.append(
+					{
+						"shipment_id": str(parcel_data["id"]),
+						"awb_number": parcel_data.get("tracking_number", ""),
+						"tracking_url": parcel_data.get("tracking_url", ""),
+						"carrier": self.get_carrier(service_info["carrier"], post_or_get="post"),
+						"carrier_service": service_info["service_name"],
+						"shipment_amount": service_info["total_price"],
+					}
+				)
 			except Exception:
-				show_error_alert(f"creating SendCloud Shipment for parcel {parcel.get('order_number')}")
-		if shipments_results:
+				show_error_alert(f"creating SendCloud Shipment for parcel {order_number}")
+				failed_parcels.append((order_number, _("Unexpected error. See Error Log.")))
+
+		if len(shipments_results) == len(parcels):
 			return {
 				"service_provider": "SendCloud",
 				"shipment_id": ", ".join(
@@ -222,7 +224,56 @@ class SendCloudUtils:
 				),
 			}
 
+		for order_number, reason in failed_parcels:
+			frappe.msgprint(
+				_("Error occurred while creating shipment for parcel {0}:").format(order_number)
+				+ f"\n{reason}",
+				indicator="red",
+				alert=True,
+			)
+
+		if shipments_results:
+			cancelled_ids = []
+			cancel_failed = []
+			for result in shipments_results:
+				shipment_id = result["shipment_id"]
+				success, error = self.cancel_shipment(shipment_id)
+				if success:
+					cancelled_ids.append(shipment_id)
+				else:
+					cancel_failed.append((shipment_id, error))
+
+			if cancelled_ids:
+				frappe.msgprint(
+					_("Cancelled SendCloud shipment IDs: {0}").format(", ".join(cancelled_ids)),
+					indicator="orange",
+					alert=True,
+				)
+			if cancel_failed:
+				failed_details = "\n".join(
+					f"ID {shipment_id}: {error}" for shipment_id, error in cancel_failed
+				)
+				frappe.msgprint(
+					_("Failed to cancel SendCloud shipment IDs (manual cleanup needed):")
+					+ f"\n{failed_details}",
+					indicator="red",
+					alert=True,
+				)
+
 		return None
+
+	def cancel_shipment(self, shipment_id):
+		try:
+			response = requests.post(
+				f"{SHIPMENTS_URL}/{shipment_id}/cancel",
+				auth=(self.api_key, self.api_secret),
+			)
+			response_data = response.json()
+			if errors := response_data.get("errors"):
+				return False, self.format_api_errors(errors)
+			return True, None
+		except Exception:
+			return False, _("Request failed")
 
 	def get_label(self, shipment_id):
 		# Retrieve shipment label from SendCloud

--- a/erpnext_shipping/erpnext_shipping/doctype/sendcloud/sendcloud.py
+++ b/erpnext_shipping/erpnext_shipping/doctype/sendcloud/sendcloud.py
@@ -407,6 +407,8 @@ class SendCloudUtils:
 		)
 
 	def should_use_multicollo(self, service_info, parcels):
+		# Only DPD reliably supports multicollo via /v3/shipments; other carriers
+		# (e.g. UPS) may report multicollo=true but fail at creation time.
 		carrier = (service_info.get("carrier") or "").lower()
 
 		return len(parcels) > 1 and carrier == "dpd" and service_info.get("multicollo")

--- a/erpnext_shipping/erpnext_shipping/doctype/sendcloud/sendcloud.py
+++ b/erpnext_shipping/erpnext_shipping/doctype/sendcloud/sendcloud.py
@@ -461,7 +461,7 @@ class SendCloudUtils:
 	def format_api_errors(self, errors):
 		return "\n".join(
 			f"Field: {(err.get('source') or {}).get('pointer', 'N/A')}, "
-			f"Code: {err.get('code', 'N/A')}, "
-			f"Detail: {err.get('detail', 'N/A')}"
+			+ f"Code: {err.get('code', 'N/A')}, "
+			+ f"Detail: {err.get('detail', 'N/A')}"
 			for err in errors
 		)

--- a/erpnext_shipping/erpnext_shipping/doctype/sendcloud/sendcloud.py
+++ b/erpnext_shipping/erpnext_shipping/doctype/sendcloud/sendcloud.py
@@ -94,13 +94,7 @@ class SendCloudUtils:
 			response_data = response.json()
 
 			if errors := response_data.get("errors"):
-				frappe.msgprint(
-					self.format_api_errors(errors),
-					title=_("SendCloud"),
-					indicator="red",
-					alert=True,
-				)
-				return []
+				frappe.throw(self.format_api_errors(errors), title=_("SendCloud"))
 
 			if "data" not in response_data or not response_data["data"]:
 				frappe.throw(_("No shipping options found for this destination."), title=_("Sendcloud"))
@@ -375,16 +369,24 @@ class SendCloudUtils:
 			return carrier_name.upper() if post_or_get == "get" else carrier_name.lower()
 
 	def get_parcel(self, parcel, shipment, index):
-		return {
-			"dimensions": {
-				"length": parcel.get("length", 0),
-				"width": parcel.get("width", 0),
-				"height": parcel.get("height", 0),
-				"unit": "cm",
-			},
+		data = {
 			"weight": {"value": flt(parcel.get("weight", 0), WEIGHT_DECIMALS), "unit": "kg"},
 			"order_number": f"{shipment}-{index}",
 		}
+
+		length = parcel.get("length", 0)
+		width = parcel.get("width", 0)
+		height = parcel.get("height", 0)
+
+		if length > 0 and width > 0 and height > 0:
+			data["dimensions"] = {
+				"length": length,
+				"width": width,
+				"height": height,
+				"unit": "cm",
+			}
+
+		return data
 
 	def extract_house_number(self, address):
 		pattern = r"\b\d+[/-]?\w*(?:-\d+\w*)?\b"

--- a/erpnext_shipping/erpnext_shipping/doctype/sendcloud/sendcloud.py
+++ b/erpnext_shipping/erpnext_shipping/doctype/sendcloud/sendcloud.py
@@ -128,17 +128,11 @@ class SendCloudUtils:
 			return []
 
 		parcels = []
-		for i, parcel in enumerate(json.loads(shipment_parcel), start=1):
-			parcel_count = parcel.get("count", 1)
-			for j in range(parcel_count):
-				parcel_data = self.get_parcel(
-					parcel,
-					shipment,
-					i,
-					j + 1,
-					parcel_count,
-				)
-				parcels.append(parcel_data)
+		index = 0
+		for parcel in json.loads(shipment_parcel):
+			for idx in range(parcel.get("count", 1)):
+				index += 1
+				parcels.append(self.get_parcel(parcel, shipment, index))
 
 		house_number, address = self.extract_house_number(pickup_address.address_line1)
 
@@ -175,149 +169,98 @@ class SendCloudUtils:
 			},
 		}
 
-		if service_info.get("multicollo"):
-			multicollo_result = self.create_multicollo_shipment(
-				shipment,
-				payload,
-				service_info,
-			)
-
-			if isinstance(multicollo_result, dict):
-				return multicollo_result
-
-			if multicollo_result == "error":
-				return None
-
-			return self.create_single_parcel_shipments(
-				payload,
-				parcels,
-				service_info,
-			)
-
-		return self.create_single_parcel_shipments(
-			payload,
-			parcels,
-			service_info,
-		)
-
-	def create_multicollo_shipment(self, shipment, payload, service_info):
-		try:
-			response = requests.post(
-				SHIPMENTS_URL,
-				json=payload,
-				auth=(self.api_key, self.api_secret),
-			)
-
-			response_data = response.json()
-
-			if errors := response_data.get("errors"):
-				if self.should_fallback_to_single_shipments(errors):
-					return None
-
-				frappe.msgprint(
-					_("Error occurred while creating shipment {0}:").format(shipment)
-					+ f"\n{self.format_api_errors(errors)}",
-					indicator="red",
-					alert=True,
-				)
-				return "error"
-
-			parcels_data = response_data.get("data", {}).get("parcels", [])
-			if parcels_data:
-				shipment_ids = [str(parcel["id"]) for parcel in parcels_data]
-				tracking_numbers = [parcel.get("tracking_number") or "" for parcel in parcels_data]
-				tracking_urls = [parcel.get("tracking_url") or "" for parcel in parcels_data]
-
-				return {
-					"service_provider": "SendCloud",
-					"shipment_id": ", ".join(shipment_ids),
-					"shipment_ids": shipment_ids,
-					"carrier": self.get_carrier(service_info["carrier"], post_or_get="post"),
-					"carrier_service": service_info["service_name"],
-					"shipment_amount": service_info["total_price"],
-					"awb_number": ", ".join(tracking_numbers),
-					"tracking_number": ", ".join(tracking_numbers),
-					"tracking_url": ", ".join(tracking_urls),
-				}
-
-		except Exception:
-			show_error_alert("creating SendCloud Shipment (multicollo)")
-			return "error"
-
-		return None
-
-	def create_single_parcel_shipments(self, payload, parcels, service_info):
-		shipments_results = []
-
-		for parcel in parcels:
-			payload_single = payload.copy()
-			payload_single["parcels"] = [parcel]
-
+		if self.should_use_multicollo(service_info, parcels):
+			# Multicollo Logic: All packages are processed in a single API call
 			try:
 				response = requests.post(
-					SHIPMENTS_ANNOUNCE_URL,
-					json=payload_single,
+					SHIPMENTS_URL,
+					json=payload,
 					auth=(self.api_key, self.api_secret),
 				)
-
 				response_data = response.json()
-
 				if errors := response_data.get("errors"):
 					frappe.msgprint(
-						_("Error occurred while creating shipment for parcel {0}:").format(
-							parcel.get("order_number")
-						)
+						_("Error occurred while creating shipment {0}:").format(shipment)
 						+ f"\n{self.format_api_errors(errors)}",
 						indicator="red",
 						alert=True,
 					)
-					continue
+					return None
 
 				parcels_data = response_data.get("data", {}).get("parcels", [])
 				if parcels_data:
-					parcel_data = parcels_data[0]
-					shipments_results.append(
-						{
-							"shipment_id": str(parcel_data["id"]),
-							"awb_number": parcel_data.get("tracking_number", ""),
-							"tracking_url": parcel_data.get("tracking_url", ""),
-							"carrier": self.get_carrier(service_info["carrier"], post_or_get="post"),
-							"carrier_service": service_info["service_name"],
-							"shipment_amount": service_info["total_price"],
-						}
-					)
-
+					shipment_ids = [str(parcel["id"]) for parcel in parcels_data]
+					tracking_numbers = [parcel.get("tracking_number") or "" for parcel in parcels_data]
+					tracking_urls = [parcel.get("tracking_url") or "" for parcel in parcels_data]
+					return {
+						"service_provider": "SendCloud",
+						"shipment_id": ", ".join(shipment_ids),
+						"carrier": self.get_carrier(service_info["carrier"], post_or_get="post"),
+						"carrier_service": service_info["service_name"],
+						"shipment_amount": service_info["total_price"],
+						"awb_number": ", ".join(tracking_numbers),
+						"tracking_url": ", ".join(tracking_urls),
+					}
 			except Exception:
-				show_error_alert(f"creating SendCloud Shipment for parcel {parcel.get('order_number')}")
+				show_error_alert("creating SendCloud Shipment (multicollo)")
+		else:
+			# Non-Multicollo Logic: A separate API call is made for each package
+			shipments_results = []
+			for parcel in parcels:
+				payload_single = payload.copy()
+				payload_single["parcels"] = [parcel]
+				try:
+					response = requests.post(
+						SHIPMENTS_ANNOUNCE_URL,
+						json=payload_single,
+						auth=(self.api_key, self.api_secret),
+					)
+					response_data = response.json()
+					if errors := response_data.get("errors"):
+						frappe.msgprint(
+							_("Error occurred while creating shipment for parcel {0}:").format(
+								parcel.get("order_number")
+							)
+							+ f"\n{self.format_api_errors(errors)}",
+							indicator="red",
+							alert=True,
+						)
+						continue
 
-		if shipments_results:
-			shipment_ids = [item["shipment_id"] for item in shipments_results if item.get("shipment_id")]
-			awb_numbers = [item["awb_number"] for item in shipments_results if item.get("awb_number")]
-			tracking_urls = [item["tracking_url"] for item in shipments_results if item.get("tracking_url")]
-
-			return {
-				"service_provider": "SendCloud",
-				"shipment_id": ", ".join(shipment_ids),
-				"shipment_ids": shipment_ids,
-				"carrier": shipments_results[0]["carrier"],
-				"carrier_service": shipments_results[0]["carrier_service"],
-				"shipment_amount": service_info["total_price"],
-				"awb_number": ", ".join(awb_numbers),
-				"tracking_number": ", ".join(awb_numbers),
-				"tracking_url": ", ".join(tracking_urls),
-			}
+					parcels_data = response_data.get("data", {}).get("parcels", [])
+					if parcels_data:
+						parcel_data = parcels_data[0]
+						shipments_results.append(
+							{
+								"shipment_id": str(parcel_data["id"]),
+								"awb_number": parcel_data.get("tracking_number", ""),
+								"tracking_url": parcel_data.get("tracking_url", ""),
+								"carrier": self.get_carrier(service_info["carrier"], post_or_get="post"),
+								"carrier_service": service_info["service_name"],
+								"shipment_amount": service_info["total_price"],
+							}
+						)
+				except Exception:
+					show_error_alert(f"creating SendCloud Shipment for parcel {parcel.get('order_number')}")
+			if shipments_results:
+				combined_result = {
+					"service_provider": "SendCloud",
+					"shipment_id": ", ".join(
+						item["shipment_id"] for item in shipments_results if item.get("shipment_id")
+					),
+					"carrier": shipments_results[0]["carrier"],
+					"carrier_service": shipments_results[0]["carrier_service"],
+					"shipment_amount": service_info["total_price"],
+					"awb_number": ", ".join(
+						item["awb_number"] for item in shipments_results if item.get("awb_number")
+					),
+					"tracking_url": ", ".join(
+						item["tracking_url"] for item in shipments_results if item.get("tracking_url")
+					),
+				}
+				return combined_result
 
 		return None
-
-	def should_fallback_to_single_shipments(self, errors):
-		for err in errors or []:
-			code = (err.get("code") or "").lower()
-			pointer = ((err.get("source") or {}).get("pointer") or "").lower()
-
-			if code == "validation_error" and pointer.startswith("/parcels"):
-				return True
-
-		return False
 
 	def get_label(self, shipment_id):
 		# Retrieve shipment label from SendCloud
@@ -431,12 +374,7 @@ class SendCloudUtils:
 		else:
 			return carrier_name.upper() if post_or_get == "get" else carrier_name.lower()
 
-	def get_parcel(self, parcel, shipment, index, count_index=1, parcel_count=1):
-		order_number = f"{shipment}-{index}"
-
-		if parcel_count > 1:
-			order_number = f"{shipment}-{index}-{count_index}"
-
+	def get_parcel(self, parcel, shipment, index):
 		return {
 			"dimensions": {
 				"length": parcel.get("length", 0),
@@ -445,7 +383,7 @@ class SendCloudUtils:
 				"unit": "cm",
 			},
 			"weight": {"value": flt(parcel.get("weight", 0), WEIGHT_DECIMALS), "unit": "kg"},
-			"order_number": order_number,
+			"order_number": f"{shipment}-{index}",
 		}
 
 	def extract_house_number(self, address):
@@ -465,3 +403,8 @@ class SendCloudUtils:
 			+ f"Detail: {err.get('detail', 'N/A')}"
 			for err in errors
 		)
+
+	def should_use_multicollo(self, service_info, parcels):
+		carrier = (service_info.get("carrier") or "").lower()
+
+		return len(parcels) > 1 and carrier == "dpd" and service_info.get("multicollo")

--- a/erpnext_shipping/erpnext_shipping/doctype/sendcloud/sendcloud.py
+++ b/erpnext_shipping/erpnext_shipping/doctype/sendcloud/sendcloud.py
@@ -19,7 +19,7 @@ WEIGHT_DECIMALS = 3
 CURRENCY_DECIMALS = 2
 
 BASE_URL = "https://panel.sendcloud.sc/api"
-FETCH_SHIPPING_OPTIONS_URL = f"{BASE_URL}/v3/fetch-shipping-options"
+SHIPPING_OPTIONS_URL = f"{BASE_URL}/v3/shipping-options"
 SHIPMENTS_URL = f"{BASE_URL}/v3/shipments"
 SHIPMENTS_ANNOUNCE_URL = f"{BASE_URL}/v3/shipments/announce"
 LABELS_URL = f"{BASE_URL}/v2/labels"
@@ -54,16 +54,38 @@ class SendCloudUtils:
 		to_country = delivery_address.country_code.upper()
 		from_country = pickup_address.country_code.upper()
 
+		parcel_data = {
+			"weight": {"value": flt(max_weight, WEIGHT_DECIMALS), "unit": "kg"},
+		}
+
+		if max_length > 0 and max_width > 0 and max_height > 0:
+			parcel_data["dimensions"] = {
+				"length": max_length,
+				"width": max_width,
+				"height": max_height,
+				"unit": "cm",
+			}
+
 		payload = {
-			"to_country_code": to_country,
-			"from_country_code": from_country,
-			"weight": {"value": max_weight, "unit": "kg"},
-			"dimensions": {"length": max_length, "width": max_width, "height": max_height, "unit": "cm"},
+			"from_address": {
+				"country_code": from_country,
+				"postal_code": pickup_address.pincode,
+				"city": pickup_address.city,
+				"address_line_1": pickup_address.address_line1,
+			},
+			"to_address": {
+				"country_code": to_country,
+				"postal_code": delivery_address.pincode,
+				"city": delivery_address.city,
+				"address_line_1": delivery_address.address_line1,
+			},
+			"parcels": [parcel_data],
+			"calculate_quotes": True,
 		}
 
 		try:
 			response = requests.post(
-				FETCH_SHIPPING_OPTIONS_URL,
+				SHIPPING_OPTIONS_URL,
 				json=payload,
 				auth=(self.api_key, self.api_secret),
 				headers={"Accept": "application/json", "Content-Type": "application/json"},
@@ -71,9 +93,14 @@ class SendCloudUtils:
 
 			response_data = response.json()
 
-			if "error" in response_data:
-				error_message = response_data["error"]["message"]
-				frappe.throw(error_message, title=_("SendCloud"))
+			if errors := response_data.get("errors"):
+				frappe.msgprint(
+					self.format_api_errors(errors),
+					title=_("SendCloud"),
+					indicator="red",
+					alert=True,
+				)
+				return []
 
 			if "data" not in response_data or not response_data["data"]:
 				frappe.throw(_("No shipping options found for this destination."), title=_("Sendcloud"))
@@ -108,6 +135,8 @@ class SendCloudUtils:
 					parcel,
 					shipment,
 					i,
+					j + 1,
+					parcel_count,
 				)
 				parcels.append(parcel_data)
 
@@ -147,109 +176,148 @@ class SendCloudUtils:
 		}
 
 		if service_info.get("multicollo"):
-			# Multicollo Logic: All packages are processed in a single API call
+			multicollo_result = self.create_multicollo_shipment(
+				shipment,
+				payload,
+				service_info,
+			)
+
+			if isinstance(multicollo_result, dict):
+				return multicollo_result
+
+			if multicollo_result == "error":
+				return None
+
+			return self.create_single_parcel_shipments(
+				payload,
+				parcels,
+				service_info,
+			)
+
+		return self.create_single_parcel_shipments(
+			payload,
+			parcels,
+			service_info,
+		)
+
+	def create_multicollo_shipment(self, shipment, payload, service_info):
+		try:
+			response = requests.post(
+				SHIPMENTS_URL,
+				json=payload,
+				auth=(self.api_key, self.api_secret),
+			)
+
+			response_data = response.json()
+
+			if errors := response_data.get("errors"):
+				if self.should_fallback_to_single_shipments(errors):
+					return None
+
+				frappe.msgprint(
+					_("Error occurred while creating shipment {0}:").format(shipment)
+					+ f"\n{self.format_api_errors(errors)}",
+					indicator="red",
+					alert=True,
+				)
+				return "error"
+
+			parcels_data = response_data.get("data", {}).get("parcels", [])
+			if parcels_data:
+				shipment_ids = [str(parcel["id"]) for parcel in parcels_data]
+				tracking_numbers = [parcel.get("tracking_number") or "" for parcel in parcels_data]
+				tracking_urls = [parcel.get("tracking_url") or "" for parcel in parcels_data]
+
+				return {
+					"service_provider": "SendCloud",
+					"shipment_id": ", ".join(shipment_ids),
+					"shipment_ids": shipment_ids,
+					"carrier": self.get_carrier(service_info["carrier"], post_or_get="post"),
+					"carrier_service": service_info["service_name"],
+					"shipment_amount": service_info["total_price"],
+					"awb_number": ", ".join(tracking_numbers),
+					"tracking_number": ", ".join(tracking_numbers),
+					"tracking_url": ", ".join(tracking_urls),
+				}
+
+		except Exception:
+			show_error_alert("creating SendCloud Shipment (multicollo)")
+			return "error"
+
+		return None
+
+	def create_single_parcel_shipments(self, payload, parcels, service_info):
+		shipments_results = []
+
+		for parcel in parcels:
+			payload_single = payload.copy()
+			payload_single["parcels"] = [parcel]
+
 			try:
 				response = requests.post(
-					SHIPMENTS_URL,
-					json=payload,
+					SHIPMENTS_ANNOUNCE_URL,
+					json=payload_single,
 					auth=(self.api_key, self.api_secret),
 				)
+
 				response_data = response.json()
-				if "errors" in response_data and response_data["errors"]:
-					error_details = [
-						f"Code: {err.get('code', 'N/A')}, Detail: {err.get('detail', 'N/A')}"
-						for err in response_data["errors"]
-					]
-					error_message = "\n".join(error_details)
+
+				if errors := response_data.get("errors"):
 					frappe.msgprint(
 						_("Error occurred while creating shipment for parcel {0}:").format(
 							parcel.get("order_number")
 						)
-						+ f"\n{error_message}",
+						+ f"\n{self.format_api_errors(errors)}",
 						indicator="red",
 						alert=True,
 					)
-					return None
+					continue
 
 				parcels_data = response_data.get("data", {}).get("parcels", [])
 				if parcels_data:
-					shipment_ids = [str(parcel["id"]) for parcel in parcels_data]
-					tracking_numbers = [parcel.get("tracking_number") or "" for parcel in parcels_data]
-					tracking_urls = [parcel.get("tracking_url") or "" for parcel in parcels_data]
-					return {
-						"service_provider": "SendCloud",
-						"shipment_id": ", ".join(shipment_ids),
-						"carrier": self.get_carrier(service_info["carrier"], post_or_get="post"),
-						"carrier_service": service_info["service_name"],
-						"shipment_amount": service_info["total_price"],
-						"awb_number": ", ".join(tracking_numbers),
-						"tracking_url": ", ".join(tracking_urls),
-					}
-			except Exception:
-				show_error_alert("creating SendCloud Shipment (multicollo)")
-		else:
-			# Non-Multicollo Logic: A separate API call is made for each package
-			shipments_results = []
-			for parcel in parcels:
-				payload_single = payload.copy()
-				payload_single["parcels"] = [parcel]
-				try:
-					response = requests.post(
-						SHIPMENTS_ANNOUNCE_URL,
-						json=payload_single,
-						auth=(self.api_key, self.api_secret),
+					parcel_data = parcels_data[0]
+					shipments_results.append(
+						{
+							"shipment_id": str(parcel_data["id"]),
+							"awb_number": parcel_data.get("tracking_number", ""),
+							"tracking_url": parcel_data.get("tracking_url", ""),
+							"carrier": self.get_carrier(service_info["carrier"], post_or_get="post"),
+							"carrier_service": service_info["service_name"],
+							"shipment_amount": service_info["total_price"],
+						}
 					)
-					response_data = response.json()
-					if "errors" in response_data and response_data["errors"]:
-						error_details = [
-							f"Code: {err.get('code', 'N/A')}, Detail: {err.get('detail', 'N/A')}"
-							for err in response_data["errors"]
-						]
-						error_message = "\n".join(error_details)
-						frappe.msgprint(
-							_("Error occurred while creating shipment for parcel {0}:").format(
-								parcel.get("order_number")
-							)
-							+ f"\n{error_message}",
-							indicator="red",
-							alert=True,
-						)
-						continue
 
-					parcels_data = response_data.get("data", {}).get("parcels", [])
-					if parcels_data:
-						parcel_data = parcels_data[0]
-						shipments_results.append(
-							{
-								"shipment_id": str(parcel_data["id"]),
-								"awb_number": parcel_data.get("tracking_number", ""),
-								"tracking_url": parcel_data.get("tracking_url", ""),
-								"carrier": self.get_carrier(service_info["carrier"], post_or_get="post"),
-								"carrier_service": service_info["service_name"],
-								"shipment_amount": service_info["total_price"],
-							}
-						)
-				except Exception:
-					show_error_alert(f"creating SendCloud Shipment for parcel {parcel.get('order_number')}")
-			if shipments_results:
-				combined_result = {
-					"service_provider": "SendCloud",
-					"shipment_id": ", ".join(
-						item["shipment_id"] for item in shipments_results if item.get("shipment_id")
-					),
-					"carrier": shipments_results[0]["carrier"],
-					"carrier_service": shipments_results[0]["carrier_service"],
-					"shipment_amount": service_info["total_price"],
-					"awb_number": ", ".join(
-						item["awb_number"] for item in shipments_results if item.get("awb_number")
-					),
-					"tracking_url": ", ".join(
-						item["tracking_url"] for item in shipments_results if item.get("tracking_url")
-					),
-				}
-				return combined_result
+			except Exception:
+				show_error_alert(f"creating SendCloud Shipment for parcel {parcel.get('order_number')}")
+
+		if shipments_results:
+			shipment_ids = [item["shipment_id"] for item in shipments_results if item.get("shipment_id")]
+			awb_numbers = [item["awb_number"] for item in shipments_results if item.get("awb_number")]
+			tracking_urls = [item["tracking_url"] for item in shipments_results if item.get("tracking_url")]
+
+			return {
+				"service_provider": "SendCloud",
+				"shipment_id": ", ".join(shipment_ids),
+				"shipment_ids": shipment_ids,
+				"carrier": shipments_results[0]["carrier"],
+				"carrier_service": shipments_results[0]["carrier_service"],
+				"shipment_amount": service_info["total_price"],
+				"awb_number": ", ".join(awb_numbers),
+				"tracking_number": ", ".join(awb_numbers),
+				"tracking_url": ", ".join(tracking_urls),
+			}
 
 		return None
+
+	def should_fallback_to_single_shipments(self, errors):
+		for err in errors or []:
+			code = (err.get("code") or "").lower()
+			pointer = ((err.get("source") or {}).get("pointer") or "").lower()
+
+			if code == "validation_error" and pointer.startswith("/parcels"):
+				return True
+
+		return False
 
 	def get_label(self, shipment_id):
 		# Retrieve shipment label from SendCloud
@@ -363,7 +431,12 @@ class SendCloudUtils:
 		else:
 			return carrier_name.upper() if post_or_get == "get" else carrier_name.lower()
 
-	def get_parcel(self, parcel, shipment, index):
+	def get_parcel(self, parcel, shipment, index, count_index=1, parcel_count=1):
+		order_number = f"{shipment}-{index}"
+
+		if parcel_count > 1:
+			order_number = f"{shipment}-{index}-{count_index}"
+
 		return {
 			"dimensions": {
 				"length": parcel.get("length", 0),
@@ -372,7 +445,7 @@ class SendCloudUtils:
 				"unit": "cm",
 			},
 			"weight": {"value": flt(parcel.get("weight", 0), WEIGHT_DECIMALS), "unit": "kg"},
-			"order_number": f"{shipment}-{index}",
+			"order_number": order_number,
 		}
 
 	def extract_house_number(self, address):
@@ -384,3 +457,11 @@ class SendCloudUtils:
 			return house_number, cleaned_address
 		else:
 			return None, None
+
+	def format_api_errors(self, errors):
+		return "\n".join(
+			f"Field: {(err.get('source') or {}).get('pointer', 'N/A')}, "
+			f"Code: {err.get('code', 'N/A')}, "
+			f"Detail: {err.get('detail', 'N/A')}"
+			for err in errors
+		)

--- a/erpnext_shipping/erpnext_shipping/doctype/sendcloud/sendcloud.py
+++ b/erpnext_shipping/erpnext_shipping/doctype/sendcloud/sendcloud.py
@@ -130,7 +130,7 @@ class SendCloudUtils:
 		index = 0
 		for parcel in json.loads(shipment_parcel):
 			self.warn_partial_dimensions(parcel)
-			for idx in range(parcel.get("count", 1)):
+			for _parcel in range(parcel.get("count", 1)):
 				index += 1
 				parcels.append(self.get_parcel(parcel, shipment, index))
 

--- a/erpnext_shipping/erpnext_shipping/doctype/sendcloud/sendcloud.py
+++ b/erpnext_shipping/erpnext_shipping/doctype/sendcloud/sendcloud.py
@@ -100,7 +100,7 @@ class SendCloudUtils:
 				frappe.throw(self.format_api_errors(errors), title=_("SendCloud"))
 
 			if "data" not in response_data or not response_data["data"]:
-				frappe.throw(_("No shipping options found for this destination."), title=_("Sendcloud"))
+				frappe.throw(_("No shipping options found for this destination."), title=_("SendCloud"))
 
 			available_services = []
 			for service in response_data["data"]:

--- a/erpnext_shipping/erpnext_shipping/doctype/sendcloud/sendcloud.py
+++ b/erpnext_shipping/erpnext_shipping/doctype/sendcloud/sendcloud.py
@@ -20,7 +20,6 @@ CURRENCY_DECIMALS = 2
 
 BASE_URL = "https://panel.sendcloud.sc/api"
 SHIPPING_OPTIONS_URL = f"{BASE_URL}/v3/shipping-options"
-SHIPMENTS_URL = f"{BASE_URL}/v3/shipments"
 SHIPMENTS_ANNOUNCE_URL = f"{BASE_URL}/v3/shipments/announce"
 LABELS_URL = f"{BASE_URL}/v2/labels"
 PARCELS_URL = f"{BASE_URL}/v2/parcels"
@@ -169,100 +168,59 @@ class SendCloudUtils:
 			},
 		}
 
-		if self.should_use_multicollo(service_info, parcels):
-			# Multicollo Logic: All packages are processed in a single API call
+		shipments_results = []
+		for parcel in parcels:
+			payload_single = payload.copy()
+			payload_single["parcels"] = [parcel]
 			try:
 				response = requests.post(
-					SHIPMENTS_URL,
-					json=payload,
+					SHIPMENTS_ANNOUNCE_URL,
+					json=payload_single,
 					auth=(self.api_key, self.api_secret),
 				)
 				response_data = response.json()
 				if errors := response_data.get("errors"):
 					frappe.msgprint(
-						_("Error occurred while creating shipment {0}:").format(shipment)
+						_("Error occurred while creating shipment for parcel {0}:").format(
+							parcel.get("order_number")
+						)
 						+ f"\n{self.format_api_errors(errors)}",
 						indicator="red",
 						alert=True,
 					)
-					return None
+					continue
 
 				parcels_data = response_data.get("data", {}).get("parcels", [])
 				if parcels_data:
-					shipment_ids = [str(parcel["id"]) for parcel in parcels_data]
-					tracking_numbers = [
-						parcel["tracking_number"] for parcel in parcels_data if parcel.get("tracking_number")
-					]
-					tracking_urls = [
-						parcel["tracking_url"] for parcel in parcels_data if parcel.get("tracking_url")
-					]
-					return {
-						"service_provider": "SendCloud",
-						"shipment_id": ", ".join(shipment_ids),
-						"carrier": self.get_carrier(service_info["carrier"], post_or_get="post"),
-						"carrier_service": service_info["service_name"],
-						"shipment_amount": service_info["total_price"],
-						"awb_number": ", ".join(tracking_numbers),
-						"tracking_url": ", ".join(tracking_urls),
-					}
-			except Exception:
-				show_error_alert("creating SendCloud Shipment (multicollo)")
-		else:
-			# Non-Multicollo Logic: A separate API call is made for each package
-			shipments_results = []
-			for parcel in parcels:
-				payload_single = payload.copy()
-				payload_single["parcels"] = [parcel]
-				try:
-					response = requests.post(
-						SHIPMENTS_ANNOUNCE_URL,
-						json=payload_single,
-						auth=(self.api_key, self.api_secret),
+					parcel_data = parcels_data[0]
+					shipments_results.append(
+						{
+							"shipment_id": str(parcel_data["id"]),
+							"awb_number": parcel_data.get("tracking_number", ""),
+							"tracking_url": parcel_data.get("tracking_url", ""),
+							"carrier": self.get_carrier(service_info["carrier"], post_or_get="post"),
+							"carrier_service": service_info["service_name"],
+							"shipment_amount": service_info["total_price"],
+						}
 					)
-					response_data = response.json()
-					if errors := response_data.get("errors"):
-						frappe.msgprint(
-							_("Error occurred while creating shipment for parcel {0}:").format(
-								parcel.get("order_number")
-							)
-							+ f"\n{self.format_api_errors(errors)}",
-							indicator="red",
-							alert=True,
-						)
-						continue
-
-					parcels_data = response_data.get("data", {}).get("parcels", [])
-					if parcels_data:
-						parcel_data = parcels_data[0]
-						shipments_results.append(
-							{
-								"shipment_id": str(parcel_data["id"]),
-								"awb_number": parcel_data.get("tracking_number", ""),
-								"tracking_url": parcel_data.get("tracking_url", ""),
-								"carrier": self.get_carrier(service_info["carrier"], post_or_get="post"),
-								"carrier_service": service_info["service_name"],
-								"shipment_amount": service_info["total_price"],
-							}
-						)
-				except Exception:
-					show_error_alert(f"creating SendCloud Shipment for parcel {parcel.get('order_number')}")
-			if shipments_results:
-				combined_result = {
-					"service_provider": "SendCloud",
-					"shipment_id": ", ".join(
-						item["shipment_id"] for item in shipments_results if item.get("shipment_id")
-					),
-					"carrier": shipments_results[0]["carrier"],
-					"carrier_service": shipments_results[0]["carrier_service"],
-					"shipment_amount": service_info["total_price"],
-					"awb_number": ", ".join(
-						item["awb_number"] for item in shipments_results if item.get("awb_number")
-					),
-					"tracking_url": ", ".join(
-						item["tracking_url"] for item in shipments_results if item.get("tracking_url")
-					),
-				}
-				return combined_result
+			except Exception:
+				show_error_alert(f"creating SendCloud Shipment for parcel {parcel.get('order_number')}")
+		if shipments_results:
+			return {
+				"service_provider": "SendCloud",
+				"shipment_id": ", ".join(
+					item["shipment_id"] for item in shipments_results if item.get("shipment_id")
+				),
+				"carrier": shipments_results[0]["carrier"],
+				"carrier_service": shipments_results[0]["carrier_service"],
+				"shipment_amount": service_info["total_price"],
+				"awb_number": ", ".join(
+					item["awb_number"] for item in shipments_results if item.get("awb_number")
+				),
+				"tracking_url": ", ".join(
+					item["tracking_url"] for item in shipments_results if item.get("tracking_url")
+				),
+			}
 
 		return None
 
@@ -358,7 +316,6 @@ class SendCloudUtils:
 		available_service.carrier = service["carrier"]["name"]
 		available_service.service_name = service["product"]["name"]
 		available_service.service_id = service["code"]
-		available_service.multicollo = service["functionalities"].get("multicollo", False)
 
 		quotes = service.get("quotes", [])
 		if quotes:
@@ -426,10 +383,3 @@ class SendCloudUtils:
 			+ f"Detail: {err.get('detail', 'N/A')}"
 			for err in errors
 		)
-
-	def should_use_multicollo(self, service_info, parcels):
-		# Only DPD reliably supports multicollo via /v3/shipments; other carriers
-		# (e.g. UPS) may report multicollo=true but fail at creation time.
-		carrier = (service_info.get("carrier") or "").lower()
-
-		return len(parcels) > 1 and carrier == "dpd" and service_info.get("multicollo")

--- a/erpnext_shipping/erpnext_shipping/doctype/sendcloud/sendcloud.py
+++ b/erpnext_shipping/erpnext_shipping/doctype/sendcloud/sendcloud.py
@@ -108,6 +108,8 @@ class SendCloudUtils:
 				available_services.append(available_service)
 
 			return available_services
+		except frappe.ValidationError:
+			raise
 		except Exception:
 			show_error_alert("fetching SendCloud prices")
 

--- a/erpnext_shipping/erpnext_shipping/utils.py
+++ b/erpnext_shipping/erpnext_shipping/utils.py
@@ -48,20 +48,6 @@ def validate_address(address):
 		frappe.throw(_("Please add a valid pincode in Address {0}.").format(address.address_title))
 
 
-def validate_parcels(doc, method=None):
-	if doc.docstatus != 0:
-		return
-
-	for parcel in doc.shipment_parcel:
-		for field in ("length", "width", "height"):
-			if (parcel.get(field) or 0) < 1:
-				frappe.throw(
-					_("Parcel row {idx}: {field_label} must be at least 1 cm.").format(
-						idx=parcel.idx, field_label=_(parcel.meta.get_label(field))
-					)
-				)
-
-
 def validate_phone(doc, method=None):
 	if doc.pickup_from_type == "Company":
 		phone_number = frappe.db.get_value("User", doc.pickup_contact_person, "phone")

--- a/erpnext_shipping/hooks.py
+++ b/erpnext_shipping/hooks.py
@@ -128,7 +128,6 @@ scheduler_events = {"daily": ["erpnext_shipping.erpnext_shipping.utils.update_tr
 doc_events = {
 	"Shipment": {
 		"validate": [
-			"erpnext_shipping.erpnext_shipping.utils.validate_parcels",
 			"erpnext_shipping.erpnext_shipping.utils.validate_phone",
 		]
 	},


### PR DESCRIPTION
### Motivation

Our client ships via SendCloud with varying, often unknown parcel dimensions. The carrier accepts this, but erpnext-shipping enforced dimensions on every **Shipment** parcel row — blocking rate fetch and label creation even when SendCloud does not require them.

### Shipment flow

Each parcel is created as a separate announced shipment via `POST /v3/shipments/announce`. Multicollo was removed from this PR; see #95 for a plan to reintroduce it with merchant-configurable carrier eligibility.

If any parcel fails during multi-parcel booking, already-created SendCloud shipments are cancelled and the **Shipment** is not marked Booked.

### Changes

- Migrate rate fetching from deprecated `POST /v3/fetch-shipping-options` to `POST /v3/shipping-options` with `from_address` / `to_address`, `parcels`, and `calculate_quotes`
- Make parcel dimensions optional for SendCloud (omit `dimensions` when length, width, or height is missing or zero)
- Remove global **Shipment** parcel-dimension validation; enforce dimensions only for LetMeShip rate fetching
- Fix parcel `order_number` indexing when a parcel row has `count > 1`
- Improve SendCloud API error formatting and avoid duplicate alerts on validation errors
- Warn when parcel dimensions are partially filled (some but not all of length/width/height set)
- Drop multicollo shipment creation (always use per-parcel announce)
- Fail closed on partial parcel booking: cancel created SendCloud shipments and return no result

### Test plan

- [ ] Fetch SendCloud rates for a **Shipment** with weight only (no dimensions)
- [ ] Create and announce a SendCloud shipment with weight only
- [ ] Fetch rates and create shipment with multiple parcels (`count > 1`) — verify distinct `order_number` values
- [ ] Confirm LetMeShip still requires dimensions and shows a clear message when missing
- [ ] Clear LetMeShip parcel dimensions after rate fetch: shipment creation is blocked and **Shipment** stays unbooked
- [ ] Confirm partially filled dimensions show an orange warning but do not block SendCloud
- [ ] Multi-parcel booking with a forced failure on parcel 2: **Shipment** stays unbooked, parcel 1 is cancelled in SendCloud